### PR TITLE
feat(website): make the entire sidebar hideable

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -181,6 +181,11 @@ export default {
         prism: {
             theme: prismThemes.github,
             darkTheme: prismThemes.dracula
+        },
+        docs : {
+            sidebar: {
+                hideable: true
+            }
         }
     }
 };


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow the documentation sidebar to be hideable by setting hideable: true in the Docusaurus config